### PR TITLE
set ETag to overwrite when updating or deleting a registration

### DIFF
--- a/source/ByteSmith.WindowsAzure.Messaging/NotificationHub.cs
+++ b/source/ByteSmith.WindowsAzure.Messaging/NotificationHub.cs
@@ -126,6 +126,7 @@ namespace ByteSmith.WindowsAzure.Messaging
 				if (String.IsNullOrEmpty(registration.RegistrationId))
 					throw new ArgumentException("RegistrationId missing.", "registration");
 
+				registration.ETag = "*";
 				return DeleteRegistration(registration);
 			}
 			catch (Exception ex)
@@ -301,6 +302,7 @@ namespace ByteSmith.WindowsAzure.Messaging
 
 			if (localRegistration != null) {
 				try {
+					localRegistration.ETag = "*";
 					registration = await UpdateRegistration (localRegistration);
 				} catch (WebException ex) {
 					if (((HttpWebResponse)ex.Response).StatusCode == HttpStatusCode.NotFound)
@@ -324,6 +326,7 @@ namespace ByteSmith.WindowsAzure.Messaging
 			if (registration == null)
 				return;
 
+			registration.ETag = "*";
 			await DeleteRegistration(registration);
 
 			DeleteLocalRegistration(templateName);


### PR DESCRIPTION
The ETag needs to be set to "*" when updating or deleting a
registration, otherwise it returns
"Error 412 Precondition Failed–ETag header missing or invalid"

This is according to the code in Microsoft.WindowsAzure.Messaging.dll,
which is the Notification Hub client for Windows Phone
